### PR TITLE
Fix attribute error falling back to core logger

### DIFF
--- a/authomatic/providers/__init__.py
+++ b/authomatic/providers/__init__.py
@@ -328,7 +328,7 @@ class BaseProvider(object):
             The actual message.
         """
 
-        logger = cls._logger or authomatic.core._logger
+        logger = getattr(cls, '_logger', None) or authomatic.core._logger
         logger.log(level, ': '.join(('authomatic', cls.__name__, msg)))
 
     


### PR DESCRIPTION
Fix `AttributeError: type object 'GitHub' has no attribute '_logger'` reusing the GitHub provider with deserialized credentials.

Sounds the same as: https://github.com/peterhudec/authomatic/issues/1#issuecomment-60454907