### PR TITLE
Yahoo OpenID error

### DIFF
--- a/authomatic/providers/openid.py
+++ b/authomatic/providers/openid.py
@@ -95,6 +95,7 @@ class SessionWrapper(object):
         val = self.session.get(key)
         if val and val.startswith(self.prefix):
             split = val.split(self.prefix)[1]
+            split = str(split)
             unpickled = pickle.loads(split)
 
             return unpickled


### PR DESCRIPTION
I was getting an error

import() argument 1 must be string without null bytes, not str

when using Yahoo OpenID. Something in pickle wasn't happy it seemed, but this appears to resolve it