### PR TITLE
Correct six local import for python3 compatibility

### DIFF
--- a/authomatic/__init__.py
+++ b/authomatic/__init__.py
@@ -18,5 +18,5 @@ and access **his/her protected resources**.
 
 """
 
-import six
+from . import six
 from .core import Authomatic, setup, login, provider_id, access, async_access, credentials, request_elements, backend


### PR DESCRIPTION
Using absolute import (`import six`) doesn't seems to work with python3 if six is not installed, relative import fix the issue.

I think you should release a new version on pypi with this fix (or add six as an explicit dependency) given the python3 version is broken without it, see the output of my `pip install -r requirement.txt`:
```
Downloading/unpacking authomatic (from -r requirements.txt (line 6))
Downloading Authomatic-0.0.11.tar.gz (814kB): 814kB downloaded
Running setup.py (path:/home/rof/src/github.com/Scille/vigiechiro-api/venv/build/authomatic/setup.py) egg_info for package authomatic
Traceback (most recent call last):
File "<string>", line 17, in <module>
File "/home/rof/src/github.com/Scille/vigiechiro-api/venv/build/authomatic/setup.py", line 3, in <module>
from authomatic import six
File "/home/rof/src/github.com/Scille/vigiechiro-api/venv/build/authomatic/authomatic/__init__.py", line 21, in <module>
import six
ImportError: No module named 'six'
Complete output from command python setup.py egg_info:
Traceback (most recent call last):

File "<string>", line 17, in <module>

File "/home/rof/src/github.com/Scille/vigiechiro-api/venv/build/authomatic/setup.py", line 3, in <module>

from authomatic import six

File "/home/rof/src/github.com/Scille/vigiechiro-api/venv/build/authomatic/authomatic/__init__.py", line 21, in <module>

import six

ImportError: No module named 'six'
```