### PR TITLE
test for binary response content, skip decoding if it is. closes #87

### DIFF
--- a/authomatic/core.py
+++ b/authomatic/core.py
@@ -1085,6 +1085,15 @@ class Response(ReprMixin):
         return self.httplib_response.getheaders()
 
 
+    def is_binary_string(self, content):
+        """
+        Return true if string is binary data
+        """
+
+        textchars = bytearray([7,8,9,10,12,13,27]) + bytearray(range(0x20, 0x100))
+        return bool(content.translate(None, textchars))
+
+
     @property
     def content(self):
         """
@@ -1092,7 +1101,11 @@ class Response(ReprMixin):
         """
 
         if not self._content:
-            self._content = self.httplib_response.read().decode('utf-8')
+            content = self.httplib_response.read()
+            if self.is_binary_string(content):
+                self._content = content
+            else:
+                self._content = content.decode('utf-8')
         return self._content
 
 

--- a/authomatic/providers/__init__.py
+++ b/authomatic/providers/__init__.py
@@ -373,7 +373,6 @@ class BaseProvider(object):
                 body = query
                 query = ''
                 headers.update({'Content-Type': 'application/x-www-form-urlencoded'})
-        print(path, query)
         request_path = parse.urlunsplit(('', '', path or '', query or '', ''))
         
         self._log(logging.DEBUG, ' \u251C\u2500 host: {0}'.format(host))


### PR DESCRIPTION
This patch checks to see if content returned from http request is binary and skips decoding step if it is. this prevents decoding binary data as utf-8 from raising an exception