### PR TITLE
provider: do not log content, it may contain non-ascii chars

### DIFF
--- a/authomatic/providers/__init__.py
+++ b/authomatic/providers/__init__.py
@@ -749,7 +749,7 @@ class AuthorizationProvider(BaseProvider):
                               max_redirects=max_redirects,
                               content_parser=content_parser)
         
-        self._log(logging.INFO, 'Got response. HTTP status = {0}. {1}'.format(response.status, response.content))
+        self._log(logging.INFO, 'Got response. HTTP status = {0}.'.format(response.status))
         return response
 
 


### PR DESCRIPTION
# Bug description

Since d87b076 (after 0.0.10 and before 0.0.11) Authomatic can't handle responses with non-ascii chars quite well and fails with:

```
Traceback (most recent call last):
  [snippet]
  File "/Wrokspace/authomatic/authomatic/core.py", line 554, in update
    return self.provider.update_user()
  File "/Wrokspace/authomatic/authomatic/providers/__init__.py", line 784, in update_user
    return self._access_user_info()
  File "/Wrokspace/authomatic/authomatic/providers/__init__.py", line 887, in _access_user_info
    response = self.access(url)
  File "/Wrokspace/authomatic/authomatic/providers/__init__.py", line 752, in access
    self._log(logging.INFO, 'Got response. HTTP status = {0}. {1}'.format(response.status, response.content))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe3' in position 11: ordinal not in range(128)
```
# Primary solution

This pull request suggests not logging the content of the response, for it may contain non-ascii characters. Please review my suggestion.

# Alternate solution

Another approach would be logging it as unicode:
```diff
 authomatic/providers/__init__.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/authomatic/providers/__init__.py b/authomatic/providers/__init__.py
index e8664a6..5beaec7 100644
--- a/authomatic/providers/__init__.py
+++ b/authomatic/providers/__init__.py
@@ -749,7 +749,7 @@ class AuthorizationProvider(BaseProvider):
                               max_redirects=max_redirects,
                               content_parser=content_parser)

-        self._log(logging.INFO, 'Got response. HTTP status = {0}. {1}'.format(response.status, response.content))
+        self._log(logging.INFO, u'Got response. HTTP status = {0}. {1}'.format(response.status, response.content))
         return response
```

But then there are quite a few other logging calls with no unicode involved that perhaps should be changed as well, such as [these](peterhudec/authomatic/blob/master/authomatic/providers/__init__.py#L379) and [these](peterhudec/authomatic/blob/master/authomatic/providers/__init__.py#L426).

# Tests

I really do intend to write tests for this but the test suite is failing with:

```
$ tox -e py27
py27 recreate: /Wrokspace/authomatic/.tox/py27
py27 installdeps: flask, pyramid, liveandletdie>=0.0.4, pytest, selenium, chromedriver-installer>=0.0.4, pyopenssl, django, gae-installer, sphinx==1.1.3, python-openid
py27 runtests: PYTHONHASHSEED='1809866630'
py27 runtests: commands[0] | py.test -vv tests/functional_tests/
================================== test session starts ==================================
platform darwin -- Python 2.7.9 -- py-1.4.26 -- pytest-2.7.0 -- /Wrokspace/authomatic/.tox/py27/bin/python2.7
rootdir: /Wrokspace/authomatic, inifile:
collected 0 items / 1 errors

======================================== ERRORS =========================================
_______________ ERROR collecting tests/functional_tests/test_providers.py _______________
.tox/py27/lib/python2.7/site-packages/py/_path/local.py:641: in pyimport
    __import__(modname)
tests/functional_tests/__init__.py:1: in <module>
    from . import fixtures
tests/functional_tests/fixtures/__init__.py:145: in <module>
    mod = importer.find_module(name).load_module(name)
/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pkgutil.py:246: in load_module
    mod = imp.load_module(fullname, self.file, self.filename, self.etc)
tests/functional_tests/expected_values/amazon.py:1: in <module>
    import fixtures
tests/functional_tests/fixtures/__init__.py:145: in <module>
    mod = importer.find_module(name).load_module(name)
/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pkgutil.py:246: in load_module
    mod = imp.load_module(fullname, self.file, self.filename, self.etc)
tests/functional_tests/expected_values/github.py:12: in <module>
    .format(conf.user_id))
.tox/py27/lib/python2.7/re.py:194: in compile
    return _compile(pattern, flags)
.tox/py27/lib/python2.7/re.py:251: in _compile
    raise error, v # invalid expression
E   error: multiple repeat
================================ 1 error in 2.86 seconds ================================
ERROR: InvocationError: '/Wrokspace/authomatic/.tox/py27/bin/py.test -vv tests/functional_tests/'
________________________________________ summary ________________________________________
ERROR:   py27: commands failed
```

Could you please help me figuring out what I am missing?

Thanks!