### PR TITLE
Facebook: do not except if error_reason and error are None

### DIFF
--- a/authomatic/providers/oauth2.py
+++ b/authomatic/providers/oauth2.py
@@ -375,7 +375,7 @@ class OAuth2(providers.AuthorizationProvider):
             error_description = self.params.get('error_description') \
                                 or error_message or error
 
-            if 'denied' in error_reason:
+            if error_reason and 'denied' in error_reason:
                 raise CancellationError(error_description,
                                         url=self.user_authorization_url)
             else:


### PR DESCRIPTION
Hello. 
Facebook may redirect with error, which cause exception

TypeError("argument of type 'NoneType' is not iterable",)

because error_reason is still None. This patch fixes this exception.

You may reproduce the error if Facebook answers the following:

"Given URL is not allowed by the Application configuration: One or more of the given URLs is not allowed by the App's settings.  It must match the Website URL or Canvas URL, or the domain must be a subdomain of one of the App's domains."
