### PR TITLE
Allow customization of FlaskAuthomatic's adapter

### DIFF
--- a/authomatic/extras/flask.py
+++ b/authomatic/extras/flask.py
@@ -20,20 +20,26 @@ from authomatic import Authomatic
 class FlaskAuthomatic(Authomatic):
     """
     Flask Plugin for authomatic support.
+
+    :param adapter_cls: Adapter class to use (default: `WerkzeugAdapter`)
     """
 
     result = None
+
+    def __init__(self, *args, **kwargs):
+        self._adapter_cls = kwargs.pop('adapter_cls', WerkzeugAdapter)
+        super(FlaskAuthomatic, self).__init__(*args, **kwargs)
 
     def login(self, *login_args, **login_kwargs):
         """
         Decorator for Flask view functions.
         """
-        
+
         def decorator(f):
             @wraps(f)
             def decorated(*args, **kwargs):
                 self.response = make_response()
-                adapter = WerkzeugAdapter(request, self.response)
+                adapter = self._adapter_cls(request, self.response)
                 login_kwargs.setdefault('session', session)
                 login_kwargs.setdefault('session_saver', self.session_saver)
                 self.result = super(FlaskAuthomatic, self).login(adapter, *login_args, **login_kwargs)


### PR DESCRIPTION
Hi there !

Following the issue #100, I've realized the most elegant way to do custom redirection is to hack the `Adapter` class. The only trouble is this is not possible with `FlaskAuthomatic`... so here is this PR !

example:
```python
# Typical need when going through a reverse proxy
class CustomUrlAdapter(WerkzeugAdapter):
    @property
    def url(self):
        return current_app.config['AUTHOMATIC_REDIRECT_URL']

# See my trouble with Heroku in issue #100 about this one
class ForceHttpsAdapter(WerkzeugAdapter):
    @property
    def url(self):
        import re
        return re.sub(r'^http://', 'https://', self.request.base_url)

fa = FlaskAuthomatic(
    config=AUTHOMATIC,
    secret=app.config['SECRET_KEY'],
    adapter_cls=CustomUrlAdapter
)
```

Maybe it should be interesting to add a word about this in the documentation, what do you think ?