### PR TITLE
Fixed the 'WSGIRequest' object has no attribute 'REQUEST' …

### DIFF
--- a/authomatic/adapters.py
+++ b/authomatic/adapters.py
@@ -145,7 +145,7 @@ class DjangoAdapter(BaseAdapter):
     
     @property
     def params(self):
-        return dict(self.request.REQUEST)
+        return dict(self.request)
     
     @property
     def url(self):


### PR DESCRIPTION
…error Django 1.9
It was a minor change. The issue was caused by the overhaul of Django's core request and response objects AFAIK.
Basically: request.REQUEST -> request